### PR TITLE
Revert module(PackageModule)

### DIFF
--- a/src/DbAppPackage.php
+++ b/src/DbAppPackage.php
@@ -7,6 +7,7 @@
  */
 namespace Koriym\DbAppPackage;
 
+use BEAR\Package\PackageModule;
 use BEAR\Package\Provide\Router\AuraRouterModule;
 use Ray\AuraSqlModule\AuraSqlModule;
 use Ray\Di\AbstractModule;
@@ -77,5 +78,6 @@ class DbAppPackage extends AbstractModule
         $this->install(new QueryLocatorModule($this->dbDir . '/sql'));
         $this->install(new SqlQueryModule($this->dbDir . '/sql'));
         $this->install(new NowModule);
+        $this->install(new PackageModule);
     }
 }


### PR DESCRIPTION
前のバージョンから現行最新バージョンに上がる際に、モジュール  "`PackageModule`" のインストールは削除されていました（下記リンク参照）。
ですが、README の内容を元に利用方法を考えると、該当モジュールは必要だと思ったので、復活させる変更を行いました。

ref. https://github.com/koriym/Koriym.DbAppPackage/commit/5bbf06b17bb3c0ecbf0b3af5803b83c19aa145e8